### PR TITLE
Enhancement #35 - Cron publish post date

### DIFF
--- a/broadcast_dashboard.info
+++ b/broadcast_dashboard.info
@@ -1,5 +1,5 @@
 ; $Id$
-; Broadcast Dashboard, v. 1.3.1
+; Broadcast Dashboard, v. 1.3.2
 ; Written by Sam Thacker
 ; For CSU Northridge's Oviatt Library
 name = Broadcast Dashboard
@@ -14,4 +14,4 @@ files[] = broadcast_dashboard.module
 ;scripts[] = broadcast_dashboard_confirm_delete.js
 ;scripts[] = broadcast_dashboard_preview_add.js
 ;scripts[] = broadcast_dashboard_color_value_set.js
-version = 7.x-1.3.1
+version = 7.x-1.3.2

--- a/broadcast_dashboard.module
+++ b/broadcast_dashboard.module
@@ -1685,6 +1685,9 @@ function broadcast_dashboard_cron() {
     // First check if we need to publish/activate
     if ((!empty($scheduler_pub)) && ($current >= $scheduler_pub)) {
       variable_set('broadcast_dashboard_active', 1);
+      // Change post date to current run
+      $msg_date = date("m/d/Y h:i:sa");
+      variable_set('broadcast_dashboard_date_message_posted', $msg_date);
       broadcast_dashboard_page_build($page);
     }
 


### PR DESCRIPTION
The post date of a scheduled message published by cron will now reflect the date and time cron fired as opposed to the date and time the form was saved.