### PR TITLE
Add custom parsing for <hr> tags to display evenly

### DIFF
--- a/broadcast_dashboard.module
+++ b/broadcast_dashboard.module
@@ -712,6 +712,9 @@ function broadcast_dashboard_page_build(&$page) {
   // No custom, push preset message
   if (($active == 1) && ($msg_id != "custom_msg")) {
     if (isset($preset_clr_class)) {
+      // Split at <hr>s
+      $preset_msg = str_replace('<hr>', '</p><hr><p role="alert" class="lead" aria-live="assertive">', $preset_msg);
+
       //$page[$region]['system_main']['#markup'] = '<div class="' . $preset_clr_class . '"><p role="alert" aria-live="assertive">' . $preset_msg . " (Posted on: " . $msg_date . ')' . '</p></div>';
       $message_content = '<div class="' . $preset_clr_class . ' bd_p"><p role="alert" class="lead" aria-live="assertive">' . $preset_msg . " (Posted on: " . $msg_date . ')' . '</p></div>';
       $page[$region]['system_main'] = array(
@@ -719,14 +722,23 @@ function broadcast_dashboard_page_build(&$page) {
       );
 
     } else if (isset($preset_clr_hex)) {
+      // Split at <hr>s
+      $preset_msg = str_replace('<hr>', '</p><hr><p role="alert" class="lead" aria-live="assertive">', $preset_msg);
+
       $page[$region]['system_main']['#markup'] = '<div class="bd_p" style="background-color: ' . $preset_clr_hex . '; padding: 15px; border: 1px solid transparent; border-radius: 4px; margin-bottom: 20px;"><p role="alert" class="lead" aria-live="assertive">' . $preset_msg . " (Posted on: " . $msg_date . ')</div>' . '</p></div>';
     }
   } else if (($active == 1) && ($msg_id == "custom_msg")) { // end no custom msg
     // For custom alerts
     // Set alert color based on setting
      if (isset($cust_msg_clr_class)) {
-      $page[$region]['system_main']['#markup'] = '<div class="' . $cust_msg_clr_class . ' bd_p"><p role="alert" class="lead" aria-live="assertive">' . $cust_msg . " (Posted on: " . $msg_date . ')' . '</p></div>';
-    } else if (isset($cust_msg_clr_hex)) {
+       // Split at <hr>s
+       $cust_msg = str_replace('<hr>', '</p><hr><p role="alert" class="lead" aria-live="assertive">', $cust_msg);
+
+       $page[$region]['system_main']['#markup'] = '<div class="' . $cust_msg_clr_class . ' bd_p"><p role="alert" class="lead" aria-live="assertive">' . $cust_msg . " (Posted on: " . $msg_date . ')' . '</p></div>';
+     } else if (isset($cust_msg_clr_hex)) {
+       // Split at <hr>s
+       $cust_msg = str_replace('<hr>', '</p><hr><p role="alert" class="lead" aria-live="assertive">', $cust_msg);
+
       $page[$region]['system_main']['#markup'] = '<div class="bd_p" style="background-color: ' . $cust_msg_clr_hex . '; padding: 15px; border: 1px solid transparent; border-radius: 4px; margin-bottom: 20px;"<p role="alert" class="lead" aria-live="assertive">' . $cust_msg . " (Posted on: " . $msg_date . ')</div>' . '</p></div>';
     }
   } // end custom msg

--- a/broadcast_dashboard.module
+++ b/broadcast_dashboard.module
@@ -739,7 +739,7 @@ function broadcast_dashboard_page_build(&$page) {
        // Split at <hr>s
        $cust_msg = str_replace('<hr>', '</p><hr><p role="alert" class="lead" aria-live="assertive">', $cust_msg);
 
-      $page[$region]['system_main']['#markup'] = '<div class="bd_p" style="background-color: ' . $cust_msg_clr_hex . '; padding: 15px; border: 1px solid transparent; border-radius: 4px; margin-bottom: 20px;"<p role="alert" class="lead" aria-live="assertive">' . $cust_msg . " (Posted on: " . $msg_date . ')</div>' . '</p></div>';
+        $page[$region]['system_main']['#markup'] = '<div class="bd_p" style="background-color: ' . $cust_msg_clr_hex . '; padding: 15px; border: 1px solid transparent; border-radius: 4px; margin-bottom: 20px;"><p role="alert" class="lead" aria-live="assertive">' . $cust_msg . " (Posted on: " . $msg_date . ')</div>' . '</p></div>';
     }
   } // end custom msg
 


### PR DESCRIPTION
### Enhancements
- Inserting `<hr>` into a message text will now parse the remainder of the text out following the `<hr>` appropriately 

### Fixes
- Fix minor tag offset issue in hex-based custom message display